### PR TITLE
Just a little optimization of the bit counting (#B) function

### DIFF
--- a/lib/jrpn16/main.dart
+++ b/lib/jrpn16/main.dart
@@ -686,10 +686,8 @@ class Operations16 extends Operations {
         int count = 0;
         BigInt v = m.x.internal;
         while (v > BigInt.zero) {
-          if ((v & BigInt.one) != BigInt.zero) {
-            count++;
-          }
-          v = v >> 1;
+          count++;
+          v &= (v - BigInt.one);
         }
         m.resultX = Value.fromInternal(BigInt.from(count));
       },


### PR DESCRIPTION
I've been playing with assembly code lately and saw this little tip on YouTube so I figured I share it.
Feel free to try it, but you don't have to use it by any means. It saves a lot of cycles by skipping 0 bits.
Thanks to [davepl](https://youtu.be/Xv1sohXaX_o?start=1170) from Microsoft.
